### PR TITLE
fix(demo): allow opening PSD files on Windows

### DIFF
--- a/examples/browser/statics/index.html
+++ b/examples/browser/statics/index.html
@@ -74,7 +74,7 @@
     <section>
       <div class="section-content">
         <h2>Select psd/psb file</h2>
-        <input type="file" accept="image/vnd.adobe.photoshop,.psb" />
+        <input type="file" accept=".psd,.psb" />
         <h2>Results</h2>
         <p>
           After the file is selected, the PSD file parsing result is shown


### PR DESCRIPTION
Due to inconsistencies in how browsers across different platforms handle the `accept` field of a file input, we need to use file extensions, rather than MIME types, to allow opening PSD files.

Fixes #1