### PR TITLE
fix: flag used for locked/visible layers

### DIFF
--- a/src/sections/LayerAndMaskInformation/readLayerRecordsAndChannels.ts
+++ b/src/sections/LayerAndMaskInformation/readLayerRecordsAndChannels.ts
@@ -203,7 +203,7 @@ function readLayerFlag(cursor: Cursor): boolean {
   // There are better ways of parsing a bitfield...
   // TODO: Rewrite this
   const flags = cursor.read("u8").toString(2).padStart(8, "0");
-  const visible = flags[7];
+  const visible = flags[6];
 
   return visible === "0";
 }


### PR DESCRIPTION
This fixes the flag used for locked vs visible layers, I have a basic psd (PS CC latest) with three layers, one locked, one visible, one not visible. The flags returned look like the following:
```

Locked layer flags:  00001001 
Visible layer flags: 00001000 
Hidden layer flags:  00001010 
```
Currently it's looking for the visible flag in position 7, rather than 6.
