### PR TITLE
Rename default branch to 'main'

### DIFF
--- a/.github/workflows/publish-demo.yml
+++ b/.github/workflows/publish-demo.yml
@@ -2,7 +2,7 @@ name: "Publish demo & benchmark pages to GitHub Pages"
 
 on:
   push:
-    branches: [master]
+    branches: [main]
 
 jobs:
   publish:

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ You can run [benchmarks for @webtoon/psd in your browser](https://webtoon.github
 
 ### Web Browsers
 
-Check out the [live demo](https://webtoon.github.io/psd) and the the [source](https://github.com/webtoon/psd/tree/master/examples/browser) for web browser.
+Check out the [live demo](https://webtoon.github.io/psd) and the the [source](https://github.com/webtoon/psd/tree/main/examples/browser) for web browser.
 
 `@webtoon/psd` must be bundled with a bundler such as Webpack or Rollup.
 
@@ -178,7 +178,7 @@ layerPixelData = layer.composite(false);
 
 ## License
 
-`@webtoon/psd` is released under the [MIT license](https://github.com/webtoon/psd/blob/master/LICENSE).
+`@webtoon/psd` is released under the [MIT license](https://github.com/webtoon/psd/blob/main/LICENSE).
 
 ```
 Copyright 2021-present NAVER WEBTOON


### PR DESCRIPTION
Back in 2022-05-13, we renamed the default branch from `master` to `main`, following [GitHub's guidelines](https://github.com/github/renaming). This PR addresses some issues that we missed:

- Change the branch name filter in the CI script that publishes GitHub Pages (`publish-demo.yml`).
- Update links in `README.md`. While GitHub does redirect them from `../master/..` to `../main/..`, it's probably best not to rely on this behavior.