### PR TITLE
ci: set fake Git user for deploying

### DIFF
--- a/.github/workflows/publish-demo.yml
+++ b/.github/workflows/publish-demo.yml
@@ -18,4 +18,4 @@ jobs:
       - name: Configure Git for pushing commits
         # Embed the access token directly into the remote URL so that the gh-pages library can pick it up
         run: git remote set-url origin https://git:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
-      - run: npm run deploy
+      - run: npm run deploy -- -u 'github-actions-bot <support+actions@github.com>'


### PR DESCRIPTION
This fixes the following CI error:

```
webpack 5.73.0 compiled with 3 warnings in 13406 ms
Author identity unknown

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: empty ident name (for <runner@fv-az74-828.rg1nhevy3x5uhivy2ou0ehszxf.jx.internal.cloudapp.net>) not allowed

Error: Process completed with exit code 1.
```

The errors were observed in the following runs:

- https://github.com/webtoon/psd/runs/6828152676?check_suite_focus=true
- https://github.com/webtoon/psd/runs/6349346363?check_suite_focus=true

This PR updates the CI script to resolve the issue, based on the following tips:

- https://github.com/tschaub/gh-pages#deploying-with-github-actions
- https://github.com/tschaub/gh-pages/issues/345#issuecomment-608243163