### PR TITLE
Followup fixes for Monorepo PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ You can run [benchmarks for @webtoon/psd in your browser](https://webtoon.github
 
 ### Web Browsers
 
-Check out the [live demo](https://webtoon.github.io/psd) and the the [source](https://github.com/webtoon/psd/tree/main/examples/browser) for web browser.
+Check out the [live demo](https://webtoon.github.io/psd) ([source code](https://github.com/webtoon/psd/tree/main/packages/example-browser)) for web browser.
 
 `@webtoon/psd` must be bundled with a bundler such as Webpack or Rollup.
 
@@ -91,6 +91,8 @@ inputEl.addEventListener("change", async () => {
 For performance, we recommend parsing PSD files in a [Web Worker](https://developer.mozilla.org/docs/Web/API/Web_Workers_API) rather than the main thread.
 
 ### NodeJS
+
+Check out the [source code for the Node.js example](https://github.com/webtoon/psd/tree/main/packages/example-node) for web browser.
 
 `@webtoon/psd` does not support the Node.js `Buffer`. You must explicitly supply the underlying `ArrayBuffer`.
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "npm -w @webtoon/psd run build",
     "clear": "rimraf packages/psd/dist/ dist-web/",
-    "deploy": "npm -w @webtoon/psd-example-browser -w @webtoon/psd-benchmark run build && gh-pages -d dist-web/",
+    "deploy": "npm -w @webtoon/psd -w @webtoon/psd-example-browser -w @webtoon/psd-benchmark run build && gh-pages -d dist-web/",
     "fix": "eslint --fix . && prettier --write .",
     "lint": "eslint . && prettier --check .",
     "prepare": "husky install",


### PR DESCRIPTION
This PR fixes issues caused by or overlooked in #19.

- Before building the browser example and benchmark web apps for deploying to GitHub Pages, (re)build the library (@webtoon/psd). This ensures that the deployment CI script (`publish-demo.yml`) runs correctly.
- Add and update links to example project sources in README.