### PR TITLE
build: fix base dir of browser-example

### DIFF
--- a/packages/example-browser/vite.config.ts
+++ b/packages/example-browser/vite.config.ts
@@ -6,6 +6,7 @@ import {defineConfig} from "vite";
 
 export default defineConfig({
   root: __dirname,
+  base: "./",
   publicDir: "statics",
   server: {
     port: 4200,


### PR DESCRIPTION
This is a follup-up PR for a bug in #20 (17682fb431371e6f30a7566b7dec32601e16b13a) that caused the asset paths for the browser example to be emitted incorrectly.