### PR TITLE
build: disable minification when testing

### DIFF
--- a/packages/psd/vite.config.ts
+++ b/packages/psd/vite.config.ts
@@ -32,7 +32,6 @@ export default defineConfig((env) => ({
   // If our code imports another package (@webtoon/psd-decoder in this case),
   // Vite disables build.minify when build.lib.formats includes 'es'.
   // Since we do not want this behavior, force esbuild to minify our code.
-  esbuild: {
-    minify: true,
-  },
+  // This must be disabled when testing; otherwise, it causes Vitest to fail.
+  esbuild: env.mode === "test" ? undefined : {minify: true},
 }));


### PR DESCRIPTION
This PR is a follow-up of #20. ESBuild minification causes Vitest to fail for unknown reasons, so we're disabling it when testing.