### PR TITLE
chore: build psd-decoder when deploying

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "npm -w @webtoon/psd-decoder -w @webtoon/psd run build",
     "clear": "rimraf packages/*/dist/ dist-web/",
-    "deploy": "npm -w @webtoon/psd -w @webtoon/psd-example-browser -w @webtoon/psd-benchmark run build && gh-pages -d dist-web/",
+    "deploy": "npm -w @webtoon/psd-decoder -w @webtoon/psd -w @webtoon/psd-example-browser -w @webtoon/psd-benchmark run build && gh-pages -d dist-web/",
     "fix": "eslint --fix . && prettier --write .",
     "lint": "eslint . && prettier --check .",
     "prepare": "husky install",


### PR DESCRIPTION
This PR fixes an oversight in #20, where the NPM `deploy` script does not build the `@webtoon/psd-decoder` package, causing the build to fail for `@webtoon/psd`, `@webtoon/example-browser`, and `@webtoon/benchmark`.