### PR TITLE
feat!: remove unwanted exports or make them type-only exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,27 +128,28 @@ const psdFile = Psd.parse(myBuffer);
 A `Psd` object contains a tree of `Layer` and `Group` (i.e. layer group) objects.
 
 - The `Psd` object provides a `children` property, which is an array of top-level `Layer`s and `Group`s.
-- Each `Group` object provides a `children` property, which is an array of `Layers` and `Group`s that belong immediately under the current layer group .
+- Each `Group` object provides a `children` property, which is an array of `Layers` and `Group`s that belong immediately under the current layer group.
+- `Psd`, `Group`, and `Layer` objects provide a `type` field, which can be used to discriminate each type:
 
 ```ts
-import Psd, {Group, Layer, Node} from "@webtoon/psd";
+import Psd, {Node} from "@webtoon/psd";
 
 // Recursively traverse layers and layer groups
 function traverseNode(node: Node) {
-  if (node instanceof Group) {
-    for (const child of node.children) {
-      traverseNode(child);
-    }
-  } else if (node instanceof Layer) {
-    // Do something with layer
+  if (node.type === "Layer") {
+    // Do something with Layer
+  } else if (node.type === "Group") {
+    // Do something with Group
+  } else if (node.type === "Psd") {
+    // Do something with Psd
   } else {
     throw new Error("Invalid node type");
   }
+
+  node.children?.forEach((child) => traverseNode(child));
 }
 
-for (const node of psdFile.children) {
-  traverseNode(node);
-}
+traverseNode(psd);
 ```
 
 The `Psd` object also provides the `layers` property, which is an array of all `Layer`s in the image (including nested).

--- a/packages/example-node/script.js
+++ b/packages/example-node/script.js
@@ -6,7 +6,7 @@ import * as fs from "fs";
 import * as path from "path";
 import {fileURLToPath} from "url";
 
-import * as Psd from "@webtoon/psd";
+import Psd from "@webtoon/psd";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -14,4 +14,4 @@ const file_path = path.resolve(__dirname, "./example.psd");
 const psd_file = fs.readFileSync(file_path);
 
 const psd = Psd.parse(psd_file.buffer);
-console.log(psd.fileHeader);
+console.log(psd);

--- a/packages/psd/src/classes/Group.ts
+++ b/packages/psd/src/classes/Group.ts
@@ -3,18 +3,22 @@
 // MIT License
 
 import {GroupFrame} from "../sections";
-import {Node} from "./Node";
+import {NodeChild, NodeParent} from "./Node";
+import {NodeBase} from "./NodeBase";
 
 /**
  * A layer group, which may contain layers and other layer groups.
  * @alpha
  */
-export class Group implements Node {
+export class Group implements NodeBase<NodeParent, NodeChild> {
   readonly type = "Group";
-  readonly children: Node[] = [];
+  readonly children: NodeChild[] = [];
 
   /** @internal */
-  constructor(private layerFrame: GroupFrame, public readonly parent: Node) {}
+  constructor(
+    private layerFrame: GroupFrame,
+    public readonly parent: NodeParent
+  ) {}
 
   get name(): string {
     return this.layerFrame.layerProperties.name;
@@ -26,7 +30,7 @@ export class Group implements Node {
     return this.parent.composedOpacity * (this.opacity / 255);
   }
 
-  addChild(node: Node): void {
+  addChild(node: NodeChild): void {
     this.children.push(node);
   }
   hasChildren(): boolean {
@@ -34,7 +38,7 @@ export class Group implements Node {
   }
 
   freeze(): void {
-    this.children.forEach((node) => node.freeze && node.freeze());
+    this.children.forEach((node) => (node as NodeBase).freeze?.());
     Object.freeze(this.children);
   }
 }

--- a/packages/psd/src/classes/Layer.ts
+++ b/packages/psd/src/classes/Layer.ts
@@ -4,18 +4,26 @@
 
 import {ImageData} from "../interfaces";
 import {LayerFrame} from "../sections";
-import {Node} from "./Node";
+import {NodeParent} from "./Node";
+import {NodeBase} from "./NodeBase";
 import {Synthesizable} from "./Synthesizable";
 
 /**
  * A layer in a PSD file.
  * @alpha
  */
-export class Layer extends Synthesizable implements Node {
+export class Layer
+  extends Synthesizable
+  implements NodeBase<NodeParent, never>
+{
   readonly type = "Layer";
+  readonly children?: undefined;
 
   /** @internal */
-  constructor(private layerFrame: LayerFrame, public readonly parent: Node) {
+  constructor(
+    private layerFrame: LayerFrame,
+    public readonly parent: NodeParent
+  ) {
     super();
   }
 

--- a/packages/psd/src/classes/Node.ts
+++ b/packages/psd/src/classes/Node.ts
@@ -2,14 +2,35 @@
 // Copyright 2021-present NAVER WEBTOON
 // MIT License
 
-export interface Node {
-  type: "Group" | "Layer" | "Psd";
-  name: string;
-  parent?: Node;
-  children?: Node[];
-  opacity: number;
-  composedOpacity: number;
-  addChild?: (node: Node) => void;
-  hasChildren?: () => boolean;
-  freeze?: () => void;
+import {PsdError} from "../utils";
+import {Group} from "./Group";
+import {Layer} from "./Layer";
+import {Psd} from "./Psd";
+
+export type Node = Psd | Group | Layer;
+export type NodeParent = Psd | Group;
+export type NodeChild = Group | Layer;
+
+export function isNodeParent(node: Node): node is NodeParent {
+  return node.type === "Psd" || node.type === "Group";
+}
+
+export function isNodeChild(node: Node): node is NodeChild {
+  return node.type === "Group" || node.type === "Layer";
+}
+
+export function assertIsNodeParent(node: Node): asserts node is NodeParent {
+  if (!isNodeParent(node)) {
+    throw new PsdError(
+      `Node (name = '${node.name}', type: '${node.type}') cannot be a parent node`
+    );
+  }
+}
+
+export function assertIsNodeChild(node: Node): asserts node is NodeChild {
+  if (!isNodeChild(node)) {
+    throw new PsdError(
+      `Node (name = '${node.name}', type: '${node.type}') cannot be a child node`
+    );
+  }
 }

--- a/packages/psd/src/classes/NodeBase.ts
+++ b/packages/psd/src/classes/NodeBase.ts
@@ -1,0 +1,20 @@
+// @webtoon/psd
+// Copyright 2021-present NAVER WEBTOON
+// MIT License
+
+import {NodeChild, NodeParent} from "./Node";
+
+export interface NodeBase<
+  Parent extends NodeParent = NodeParent,
+  Child extends NodeChild = NodeChild
+> {
+  type: "Psd" | "Group" | "Layer";
+  name: string;
+  parent?: Parent;
+  children?: Child[];
+  opacity: number;
+  composedOpacity: number;
+  addChild?: (node: Child) => void;
+  hasChildren?: () => boolean;
+  freeze?: () => void;
+}

--- a/packages/psd/src/index.ts
+++ b/packages/psd/src/index.ts
@@ -7,6 +7,5 @@ import {Psd} from "./classes";
 export type {Group, Layer, Node, NodeChild, NodeParent, Slice} from "./classes";
 export {ColorMode, Depth, GuideDirection, SliceOrigin} from "./interfaces";
 export type {Guide} from "./interfaces";
-export {parse} from "./methods";
 
 export default Psd;

--- a/packages/psd/src/index.ts
+++ b/packages/psd/src/index.ts
@@ -4,7 +4,7 @@
 
 import {Psd} from "./classes";
 
-export {Group, Layer, Slice} from "./classes";
+export type {Group, Layer, Node, NodeChild, NodeParent, Slice} from "./classes";
 export {ColorMode, Depth, GuideDirection, SliceOrigin} from "./interfaces";
 export type {Guide} from "./interfaces";
 export {parse} from "./methods";


### PR DESCRIPTION
Currently, we export many values including classes (`Layer`, `Group`) and methods (`parse()`). These expose implementation details and enable unsupported workflows (e.g. instantiating a `Group` directly).

To prevent this, we reduced our API surface:

- Remove named export: `parse()` (not to be confused with `Psd.parse()`, which is a static method on the _default-exported_ `Psd` class)
- Only export as types: `Layer`, `Group`

We also refactored our code to continue supporting some workflows (e.g. `traverseNode()`).

Note: We still export enums (`ColorMode`, `Depth`, `GuideDirection`, `SliceOrigin`) by value.