### PR TITLE
build: remove opt-level = 's'

### DIFF
--- a/packages/decoder/Cargo.toml
+++ b/packages/decoder/Cargo.toml
@@ -44,8 +44,6 @@ web-sys = {version = "0.3.57", features = ["console"]}
 wasm-bindgen-test = "0.3.30"
 
 [profile.release]
-# Tell `rustc` to optimize for small code size.
-opt-level = "s"
 # This makes the compiled code faster and smaller, but it makes compiling slower,
 # so it's only enabled in release mode.
 lto = true


### PR DESCRIPTION
This option is [supposed to make the output WASM smaller](https://doc.rust-lang.org/cargo/reference/profiles.html#opt-level), but it actually makes the bundle slightly bigger by ~200 bytes.

Also, there is a [report](https://github.com/rustwasm/wasm-pack-template/issues/27) that this flag may cause performance issues.

Thus, let's disable it for now.
