### PR TITLE
fix: handle empty channel data

### DIFF
--- a/packages/psd/src/sections/LayerAndMaskInformation/readLayerRecordsAndChannels.ts
+++ b/packages/psd/src/sections/LayerAndMaskInformation/readLayerRecordsAndChannels.ts
@@ -247,7 +247,10 @@ function readLayerChannels(
         // Compressed bytes per scanline are encoded at the beginning as 2 bytes per scanline
 
         const bytesPerScanline = fileVersionSpec.rleScanlineLengthFieldSize;
-        const skip = scanLines * bytesPerScanline;
+        // Do not attempt to skip more than the length of the channel data.
+        // This is needed because some layers (e.g. gradient fill layers) may
+        // have empty channel data (channelDataLength === 0).
+        const skip = Math.min(channelDataLength, scanLines * bytesPerScanline);
         const data = new Uint8Array(
           channelData.buffer,
           channelData.byteOffset + skip,


### PR DESCRIPTION
Some layers (e.g. gradient fill layers) may have empty channel data. Previously, attempting to skip over the scan lines in such channels resulted in buffer overflow (`RangeError`).

Let's avoid this by limiting the skip amount to the size of the channel data. This ensures that empty channels cannot be "skipped" at all.

Note: This appears to render the layer as a 1x1 empty image. Although this is not ideal, we can't do anything about it. Synthesizing a layer image from its gradient metadata is currently beyond our scope.

Fixes #40