### PR TITLE
Psd.composite() note about "Maximize Compatibility"

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ for (const layer of psdFile.layers) {
 
 Use `Psd.prototype.composite()` and `Layer.prototype.composite()` to decode the pixel information for the entire image or an individual layer.
 
-Note that for `Psd.prototype.composite()` to work, PSD/PSB files need to be saved in "Maximize Compatibility" mode. Otherwise, it will return no data. You can enable it in `Preferences > File Handling > File Compatibility > Maximizize PSD and PSB File Compatibility`
+Note that for `Psd.prototype.composite()` to work, PSD/PSB files need to be saved in "Maximize Compatibility" mode. Otherwise, it will return no data. You can enable it in `Preferences > File Handling > File Compatibility > Maximize PSD and PSB File Compatibility`
 
 ```ts
 // Decode the pixel data of the entire image

--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ for (const layer of psdFile.layers) {
 
 Use `Psd.prototype.composite()` and `Layer.prototype.composite()` to decode the pixel information for the entire image or an individual layer.
 
+Note that for `Psd.prototype.composite()` to work, PSD/PSB files need to be saved in "Maximize Compatibility" mode. Otherwise, it will return no data. You can enable it in `Preferences > File Handling > File Compatibility > Maximizize PSD and PSB File Compatibility`
+
 ```ts
 // Decode the pixel data of the entire image
 pixelData = await psd.composite();


### PR DESCRIPTION
AFAIK only the pixel data of the entire image needs the PSD/PSB to be saved with "Maximize Compatibility". I've tested this.

I didn't test for `layer.composite()`. I suspect layers don't need it.

By the way: beautiful library!! I've just tested it with [ZMOK](https://github.com/MARTYR-X-LTD/ZMOK) coming from psd.js and made really noticeable speed improvements. Impressive work 🎉