### PR TITLE
Update README.md web browser example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,9 @@ inputEl.addEventListener("change", async () => {
 
   const canvasElement = document.createElement("canvas");
   const context = canvasElement.getContext("2d");
+  const compositeBuffer = await psdFile.composite();
   const imageData = new ImageData(
-    psdFile.composite(),
+    compositeBuffer,
     psdFile.width,
     psdFile.height
   );


### PR DESCRIPTION
readme.md web browser example not working.

## Before
https://github.com/webtoon/psd/blob/8885f167ac1382a14facea47413dd9fb85bac924/README.md?plain=1#L77-L81

`psdFile.composite` function return `Promise<Uint8ClampedArray>` 
![image](https://user-images.githubusercontent.com/22269524/185074085-12152db2-9c93-4e22-a6a1-b4c08b31cb61.png)

so readme.md example causing error like this
![image](https://user-images.githubusercontent.com/22269524/185073947-b1cdc8a3-73a4-47a4-9f22-5aff16d3fceb.png)

## After
so i added `await` keyword for psdFile.composite async func

```ts
  const compositeBuffer = await psdFile.composite(); // composite function return Promise
  const imageData = new ImageData(
    compositeBuffer,
    psdFile.width,
    psdFile.height
  );
```