### PR TITLE
build: properly enable source map

### DIFF
--- a/packages/decoder/vite.config.ts
+++ b/packages/decoder/vite.config.ts
@@ -14,6 +14,10 @@ export default defineConfig({
       fileName: () => "index.js",
       formats: ["es"],
     },
+    // Enabling source maps for @webtoon/psd-decoder appears to do nothing.
+    // This may be because we use vite-plugin-top-level-await to transform code,
+    // and the plugin does not support source maps.
+    // sourcemap: true,
   },
   plugins: [
     wasm(),

--- a/packages/psd/vite.config.ts
+++ b/packages/psd/vite.config.ts
@@ -26,6 +26,7 @@ export default defineConfig((env) => ({
         }),
       ],
     },
+    sourcemap: true,
   },
   // If our code imports another package (@webtoon/psd-decoder in this case),
   // Vite disables build.minify when build.lib.formats includes 'es'.


### PR DESCRIPTION
Properly generate a source map during build. We were already generating source maps (using `tsc`) for type definitions. However, these only helped our DX and did nothing for our users--because we don't publish the source (*.ts) files, the source maps were broken.

Now we provide a proper source map generated by Vite, so that users can properly debug @webtoon/psd.