### PR TITLE
[api change] Make additionalProperties a Record

### DIFF
--- a/packages/psd/src/classes/Group.ts
+++ b/packages/psd/src/classes/Group.ts
@@ -2,7 +2,7 @@
 // Copyright 2021-present NAVER WEBTOON
 // MIT License
 
-import {GroupFrame} from "../sections";
+import {GroupFrame, LayerProperties} from "../sections";
 import {NodeChild, NodeParent} from "./Node";
 import {NodeBase} from "./NodeBase";
 
@@ -28,6 +28,12 @@ export class Group implements NodeBase<NodeParent, NodeChild> {
   }
   get composedOpacity(): number {
     return this.parent.composedOpacity * (this.opacity / 255);
+  }
+
+  get additionalProperties():
+    | LayerProperties["additionalLayerProperties"]
+    | undefined {
+    return this.layerFrame?.layerProperties.additionalLayerProperties;
   }
 
   addChild(node: NodeChild): void {

--- a/packages/psd/src/classes/Psd.ts
+++ b/packages/psd/src/classes/Psd.ts
@@ -38,7 +38,7 @@ export class Psd extends Synthesizable implements NodeBase<never, NodeChild> {
   public readonly globalLightAngle?: number = undefined;
   public readonly globalLightAltitude?: number = undefined;
   public readonly resolutionInfo?: ResolutionInfo = undefined;
-  public readonly additionalLayerProperties: AdditionalLayerProperties = [];
+  public readonly additionalLayerProperties: AdditionalLayerProperties = {};
 
   static parse(buffer: ArrayBuffer): Psd {
     const parsingResult = parse(buffer);

--- a/packages/psd/src/index.ts
+++ b/packages/psd/src/index.ts
@@ -12,6 +12,8 @@ export {
   SliceOrigin,
   DimensionUnit,
   ResolutionUnit,
+  AliKey,
+  PathRecordType,
 } from "./interfaces";
 export type {Guide} from "./interfaces";
 

--- a/packages/psd/src/sections/LayerAndMaskInformation/interfaces.ts
+++ b/packages/psd/src/sections/LayerAndMaskInformation/interfaces.ts
@@ -11,6 +11,7 @@ import {
   EngineData,
   GroupDivider,
 } from "../../interfaces";
+import {fromEntries} from "../../utils/object";
 
 export interface LayerRecord {
   name: string;
@@ -90,7 +91,7 @@ export const createLayerProperties = (
     additionalLayerInfos,
   } = layerRecord;
 
-  const additionalLayerProperties = Object.fromEntries(
+  const additionalLayerProperties = fromEntries(
     additionalLayerInfos.map((ali) => [ali.key, ali])
   ) as AdditionalLayerProperties;
 

--- a/packages/psd/src/sections/LayerAndMaskInformation/interfaces.ts
+++ b/packages/psd/src/sections/LayerAndMaskInformation/interfaces.ts
@@ -45,7 +45,9 @@ export interface Frame {
   layerRecord?: LayerRecord;
 }
 
-export type AdditionalLayerProperties = AdditionalLayerInfo[];
+export type AdditionalLayerProperties = {
+  [K in AdditionalLayerInfo as K["key"]]?: K;
+};
 
 export interface LayerProperties {
   name: string;
@@ -88,6 +90,10 @@ export const createLayerProperties = (
     additionalLayerInfos,
   } = layerRecord;
 
+  const additionalLayerProperties = Object.fromEntries(
+    additionalLayerInfos.map((ali) => [ali.key, ali])
+  ) as AdditionalLayerProperties;
+
   return {
     name,
     top,
@@ -103,7 +109,7 @@ export const createLayerProperties = (
     text: layerText,
     textProperties: engineData,
     maskData,
-    additionalLayerProperties: additionalLayerInfos,
+    additionalLayerProperties,
   };
 };
 

--- a/packages/psd/src/sections/LayerAndMaskInformation/readLayerRecordsAndChannels.ts
+++ b/packages/psd/src/sections/LayerAndMaskInformation/readLayerRecordsAndChannels.ts
@@ -23,6 +23,7 @@ import {
   InvalidBlendingModeSignature,
   ReadType,
 } from "../../utils";
+import {fromEntries} from "../../utils/object";
 import {readAdditionalLayerInfo} from "./AdditionalLayerInfo";
 import {
   MaskData,
@@ -209,7 +210,7 @@ export function readGlobalAdditionalLayerInformation(
     );
   }
 
-  return Object.fromEntries(
+  return fromEntries(
     additionalLayerInfos.map((ali) => [ali.key, ali])
   ) as AdditionalLayerProperties;
 }

--- a/packages/psd/src/sections/LayerAndMaskInformation/readLayerRecordsAndChannels.ts
+++ b/packages/psd/src/sections/LayerAndMaskInformation/readLayerRecordsAndChannels.ts
@@ -209,7 +209,9 @@ export function readGlobalAdditionalLayerInformation(
     );
   }
 
-  return additionalLayerInfos;
+  return Object.fromEntries(
+    additionalLayerInfos.map((ali) => [ali.key, ali])
+  ) as AdditionalLayerProperties;
 }
 
 function readLayerRectangle(cursor: Cursor): [number, number, number, number] {

--- a/packages/psd/src/utils/object.ts
+++ b/packages/psd/src/utils/object.ts
@@ -1,0 +1,15 @@
+// @webtoon/psd
+// Copyright 2021-present NAVER WEBTOON
+// MIT License
+
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/fromEntries
+// Unforunately not available in Node 14 according to Typescript
+export function fromEntries<K extends string | number, V>(
+  iterable: Iterable<[K, V]>
+): Record<K, V> {
+  const obj = {} as Record<K, V>;
+  for (const [k, value] of iterable) {
+    obj[k] = value;
+  }
+  return obj;
+}

--- a/packages/psd/tests/integration/fillAdjustments.test.ts
+++ b/packages/psd/tests/integration/fillAdjustments.test.ts
@@ -7,8 +7,7 @@ import * as path from "path";
 import {beforeAll, describe, expect, it} from "vitest";
 
 import type Psd from "../../src/index";
-import PSD from "../../src/index";
-import {AliKey} from "../../src/interfaces";
+import PSD, {AliKey} from "../../src/index";
 
 const FIXTURE_DIR = path.join(__dirname, "fixtures");
 
@@ -22,9 +21,7 @@ describe("adjustements parsing", () => {
   });
 
   it("describe HSL changes", () => {
-    const hue = psd.layers[10].additionalProperties.find(
-      ({key}) => key === AliKey.HueSaturation
-    );
+    const hue = psd.layers[10].additionalProperties[AliKey.HueSaturation];
 
     expect(hue).toStrictEqual({
       adjustment: [

--- a/packages/psd/tests/integration/placedLayer.test.ts
+++ b/packages/psd/tests/integration/placedLayer.test.ts
@@ -9,12 +9,7 @@ import {beforeAll, describe, expect, it} from "vitest";
 
 import type Psd from "../../src/index";
 import PSD from "../../src/index";
-import {
-  AliKey,
-  LinkedLayerAliBlock,
-  SmartObjectPlacedLayerDataAliBlock,
-  StringDescriptorValue,
-} from "../../src/interfaces";
+import {AliKey, StringDescriptorValue} from "../../src/interfaces";
 
 const FIXTURE_DIR = path.join(__dirname, "fixtures");
 
@@ -26,21 +21,18 @@ describe("placed layer data parsing", () => {
   });
 
   it("should contain links to placed files inside layers", () => {
-    const placedObject = psd.layers[0].additionalProperties.find(
-      ({key}) => key === AliKey.PlacedLayerData
-    ) as SmartObjectPlacedLayerDataAliBlock;
+    const placedObject =
+      psd.layers[0].additionalProperties[AliKey.PlacedLayerData];
 
-    const id = placedObject.data.descriptor.items.get(
+    const id = placedObject?.data.descriptor.items.get(
       "Idnt"
     ) as StringDescriptorValue;
     expect(id.value).toStrictEqual("5a96c404-ab9c-1177-97ef-96ca454b82b7");
   });
 
   it("should contain embedded files as extra resources", () => {
-    const linkedLayer = psd.additionalLayerProperties.find(
-      ({key}) => key === AliKey.LinkedLayer2
-    ) as LinkedLayerAliBlock;
-    expect(linkedLayer.layers[0]).toContain({
+    const linkedLayer = psd.additionalLayerProperties[AliKey.LinkedLayer2];
+    expect(linkedLayer?.layers[0]).toContain({
       uniqueId: "5a96c404-ab9c-1177-97ef-96ca454b82b7",
       filename: "linked-layer.png",
       filetype: "png ",
@@ -48,7 +40,7 @@ describe("placed layer data parsing", () => {
 
     const hash = crypto
       .createHash("sha256")
-      .update(linkedLayer.layers[0].contents)
+      .update(linkedLayer?.layers[0].contents ?? "")
       .digest("hex");
 
     // NOTE: when changing the hash, please make sure the result is coherent :)

--- a/packages/psd/tests/integration/vectorMask.test.ts
+++ b/packages/psd/tests/integration/vectorMask.test.ts
@@ -7,8 +7,7 @@ import * as path from "path";
 import {beforeAll, describe, expect, it} from "vitest";
 
 import type Psd from "../../src/index";
-import PSD from "../../src/index";
-import {AliKey, PathRecordType} from "../../src/interfaces";
+import PSD, {AliKey, PathRecordType} from "../../src/index";
 
 const FIXTURE_DIR = path.join(__dirname, "fixtures");
 
@@ -20,9 +19,7 @@ describe("vector mask parsing", () => {
   });
 
   it("should return pathRecords to build vector mask", () => {
-    const vmsk = psd.layers[0].additionalProperties.find(
-      ({key}) => key === AliKey.VectorMaskSetting1
-    );
+    const vmsk = psd.layers[0].additionalProperties[AliKey.VectorMaskSetting1];
 
     expect(vmsk).toStrictEqual({
       key: "vmsk",


### PR DESCRIPTION
Sorry I didn't make this work when introducing this feature, but I didn't know enough TypeScript. Anyhow, Record type is better here, since it makes checking keys much more efficient.

Also, a couple of additional quality-of-life-changes:
- expose `AliKey` as part of public API,
- expose `additionalProperties` on Group (things like `ArtboardData` are on Group, not Layer).

Let me know WDYT :)