### PR TITLE
chore: Help rust-analyzer discover Cargo.toml

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "rust-analyzer.linkedProjects": ["packages/decoder/Cargo.toml"]
+}


### PR DESCRIPTION
The [rust-analyzer](https://github.com/rust-lang/rust-analyzer) plugin for VS Code cannot discover our `Cargo.toml` because it is two levels below the root directory, and rust-analyzer only searches one level deep by default. (See https://github.com/rust-lang/rust-analyzer/pull/3309 for rationale)

To remedy this, let's add a per-project configuration file for VS Code that specifies the path to `Cargo.toml`.