### PR TITLE
Bugfix: Fixed issue with file not opening when PSB & Smart Object are present

### DIFF
--- a/packages/psd/src/sections/LayerAndMaskInformation/AdditionalLayerInfo/index.ts
+++ b/packages/psd/src/sections/LayerAndMaskInformation/AdditionalLayerInfo/index.ts
@@ -144,11 +144,12 @@ function getAliLengthFieldSizeType(
       case "Mtrn":
       case "Alph":
       case "FMsk":
-      case "Ink2":
+      case "lnk2":
       case "FEid":
       case "FXid":
       case "PxSD":
       case "cinf": // Undocumented in Adobe's docs
+      case "lnkE": // Undocumented in Adobe's docs
         return "u64";
     }
   }


### PR DESCRIPTION
# Issue
I encountered an issue where PSB files containing Smart Object Layers couldn't be opened correctly.

I found that the problem originated from an error in the getAliLengthFieldSizeType() of the Additional Layer Information.

As specified in the Adobe documentation (https://www.adobe.com/devnet-apps/photoshop/fileformatashtml/#50577409_pgfId-1049436), there was a typographical error in the key "lnk2". 
In addition, during testing, I discovered an unaccounted key "lnkE", which I've also added to the appropriate sections.

# Test
![screenshot](https://github.com/webtoon/psd/assets/40227751/74ec3559-f90f-4e47-9d1e-82e829e929f0)

To test these changes, I created a PSB file that contains Smart Object Layers. 
Prior to the changes, the file couldn't be opened, but after applying the corrections, the file opened successfully.

I kindly request a review of this pull request.