### PR TITLE
Add layerId in LayerProperties & LayerRecord

### DIFF
--- a/packages/psd/src/classes/Layer.ts
+++ b/packages/psd/src/classes/Layer.ts
@@ -115,4 +115,8 @@ export class Layer
   get clipping(): Clipping {
     return this.layerFrame.layerProperties.clippingMask;
   }
+
+  get layerId(): number {
+    return this.layerFrame.layerProperties.layerId;
+  }
 }

--- a/packages/psd/src/sections/LayerAndMaskInformation/interfaces.ts
+++ b/packages/psd/src/sections/LayerAndMaskInformation/interfaces.ts
@@ -35,6 +35,7 @@ export interface LayerRecord {
   /** If defined, containts extra text properties */
   engineData?: EngineData;
   maskData?: MaskData;
+  layerId: number;
 }
 
 export type LayerChannels = Map<ChannelKind, ChannelBytes>;
@@ -69,6 +70,7 @@ export interface LayerProperties {
   textProperties?: EngineData;
   maskData?: MaskData;
   additionalLayerProperties: AdditionalLayerProperties;
+  layerId: number;
 }
 
 export const createLayerProperties = (
@@ -90,6 +92,7 @@ export const createLayerProperties = (
     engineData,
     maskData,
     additionalLayerInfos,
+    layerId,
   } = layerRecord;
 
   const additionalLayerProperties = fromEntries(
@@ -112,6 +115,7 @@ export const createLayerProperties = (
     textProperties: engineData,
     maskData,
     additionalLayerProperties,
+    layerId,
   };
 };
 

--- a/packages/psd/src/sections/LayerAndMaskInformation/readLayerRecordsAndChannels.ts
+++ b/packages/psd/src/sections/LayerAndMaskInformation/readLayerRecordsAndChannels.ts
@@ -161,6 +161,7 @@ function readLayerRecord(
   let dividerType: LayerRecord["dividerType"];
   let layerText: LayerRecord["layerText"];
   let engineData: LayerRecord["engineData"];
+  let layerId = -1;
 
   for (const ali of additionalLayerInfos) {
     if (ali._isUnknown) continue;
@@ -188,6 +189,9 @@ function readLayerRecord(
         // Use unicode name instead of ASCII name
         ({name} = ali);
         break;
+      case AliKey.LayerId:
+        layerId = ali.value;
+        break;
     }
   }
 
@@ -208,6 +212,7 @@ function readLayerRecord(
     layerText,
     engineData,
     maskData,
+    layerId,
   };
 }
 


### PR DESCRIPTION
## Summary
Added layerId Field to Layer Object

### Description:
 - Added the layerId field directly to the layer object for easier mapping during future PSD parsing.
 - In my project, I wanted to do some layer mapping if the user parses the same PSD in the future.